### PR TITLE
Better response messages

### DIFF
--- a/app/api/api_v1/endpoints/login.py
+++ b/app/api/api_v1/endpoints/login.py
@@ -18,10 +18,6 @@ from app.services import user_services
 
 router = APIRouter()
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
-
-
 @router.post("/login/access-token", response_model=schemas.Token)
 def login_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
@@ -30,13 +26,12 @@ def login_access_token(
     """
     OAuth2 compatible token login, get an access token for future requests
     """
-    logger.debug("form data: %s", form_data)
     user_id = user_services.authenticate(
         email=form_data.username, password=form_data.password, uow=user_uow
     )
     if not user_id:
         raise HTTPException(
-            status_code=400, detail="Incorrect email or password"
+            status_code=401, detail="Incorrect email or password"
         )
     return {
         "access_token": security.create_access_token(user_id),

--- a/app/api/api_v1/endpoints/users.py
+++ b/app/api/api_v1/endpoints/users.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Optional
 
 from fastapi.encoders import jsonable_encoder
 from fastapi import APIRouter, Body, Depends, HTTPException
@@ -36,7 +36,7 @@ def create_user(
     """
     try:
         user = user_services.create_user(user_in, user_uow)
-    except user_services.DuplicateException:
+    except user_services.UserAlreadyExists:
         raise HTTPException(
             status_code=400,
             detail="The user with this username already exists in the system.",
@@ -117,7 +117,7 @@ def read_user_by_id(
     user_id: user_id,
     user_uow: SqlAlchemyUnitOfWork = Depends(get_sqlalchemy_uow),
     current_user: User = Depends(user_services.get_current_user),
-) -> Any:
+) -> Optional[User]:
     """
     Get a specific user by id.
     """

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from app.services.user_services import InvalidToken,  UserNotFound, UserAlreadyExists
+
+def apply_exception_handlers(app: FastAPI):
+    @app.exception_handler(InvalidToken)
+    def invalid_token_handler(request: Request, e: InvalidToken):
+        return JSONResponse(
+            status_code=401,
+            content={"message": "Token provided is invalid"}
+        )
+
+    @app.exception_handler(UserNotFound)
+    def user_not_found_handler(request: Request, e: UserNotFound):
+        return JSONResponse(
+            status_code=404,
+            content={"message": f"User {e.user} does not exist"}
+        )
+
+    @app.exception_handler(UserAlreadyExists)
+    def user_already_exists_handler(request: Request, e: UserAlreadyExists):
+        return JSONResponse(
+            status_code=401,
+            content={"message": f"User {e.user_name} already exists"}
+        )

--- a/app/initial_data.py
+++ b/app/initial_data.py
@@ -19,7 +19,7 @@ def init() -> None:
     )
     try:
         user_services.create_user(create_obj=user_in, uow=get_sqlalchemy_uow())
-    except user_services.DuplicateException:
+    except user_services.UserAlreadyExists:
         pass
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from starlette.middleware.cors import CORSMiddleware
 from app.api.api_v1.api import api_router
 from app.core.config import settings
 from app.initial_data import init_in_memory_songs
+from app.core.exceptions import apply_exception_handlers
 
 # Bootstrapping section. Might move this in a separate script
 init_in_memory_songs()
@@ -12,6 +13,8 @@ app = FastAPI(
     title=settings.PROJECT_NAME,
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
 )
+
+apply_exception_handlers(app)
 
 # Set all CORS enabled origins
 if settings.BACKEND_CORS_ORIGINS:


### PR DESCRIPTION
Make responses more meaningful.
Instead of `Internal server error`, say something like `Invalid token`. Instead of getting a `null` result, get a 404.
Also, add custom exceptions handling in FastAPI for this.